### PR TITLE
Move lock to the instance instead of driver

### DIFF
--- a/lib/kitchen/driver/localhost.rb
+++ b/lib/kitchen/driver/localhost.rb
@@ -36,39 +36,10 @@ module Kitchen
       plugin_version Kitchen::Localhost::VERSION
 
       #
-      # Define a Mutex at the class level so we can prevent instances using
-      # this driver from colliding.
-      #
-      # @return [Mutex]
-      #
-      def self.lock
-        @lock ||= Mutex.new
-      end
-
-      #
-      # Lock the class-level Mutex, whatever state it's in currently.
-      #
-      def self.lock!
-        lock.lock
-      end
-
-      #
-      # Unlock the class-level Mutex, whatever state it's in currently.
-      #
-      def self.unlock!
-        # Mutex#unlock raises an exception if lock is owned by another thread
-        # and Mutex#owned? isn't available in Ruby 1.9.
-        lock.unlock if lock.locked?
-      rescue ThreadError
-        nil
-      end
-
-      #
       # Create the temp dirs on the local filesystem for Kitchen.
       #
       # (see Base#create)
       def create(state)
-        self.class.lock!
         state[:hostname] = Socket.gethostname
         logger.info("[Localhost] Instance #{instance} ready.")
       end
@@ -85,7 +56,6 @@ module Kitchen
           rm_rf(p)
           logger.info("[Localhost] Deleted temp dir '#{p}'.")
         end
-        self.class.unlock!
       end
     end
   end

--- a/spec/kitchen/driver/localhost_spec.rb
+++ b/spec/kitchen/driver/localhost_spec.rb
@@ -22,80 +22,12 @@ describe Kitchen::Driver::Localhost do
     expect(res).to match(expected)
   end
 
-  describe '.lock' do
-    it 'returns a Mutex' do
-      expect(described_class.lock).to be_an_instance_of(Mutex)
-    end
-  end
-
-  describe '.lock!' do
-    let(:lock) { double(lock: true) }
-
-    before(:each) do
-      allow(described_class).to receive(:lock).and_return(lock)
-    end
-
-    it 'requests a lock from the class-level Mutex' do
-      expect(lock).to receive(:lock)
-      described_class.lock!
-    end
-  end
-
-  describe '.unlock!' do
-    let(:locked?) { nil }
-    let(:owned?) { nil }
-    let(:lock) { double(locked?: locked?) }
-
-    before(:each) do
-      if owned?
-        allow(lock).to receive(:unlock)
-      else
-        allow(lock).to receive(:unlock).and_raise(ThreadError)
-      end
-      allow(described_class).to receive(:lock).and_return(lock)
-    end
-
-    context 'already locked and owned' do
-      let(:locked?) { true }
-      let(:owned?) { true }
-
-      it 'tries to unlock without error' do
-        expect(lock).to receive(:unlock)
-        described_class.unlock!
-      end
-    end
-
-    context 'locked and not owned' do
-      let(:locked?) { true }
-      let(:owned?) { false }
-
-      it 'tries to unlock without error' do
-        expect(lock).to receive(:unlock)
-        described_class.unlock!
-      end
-    end
-
-    context 'not locked' do
-      let(:locked!) { false }
-
-      it 'does nothing' do
-        expect(lock).not_to receive(:unlock)
-        described_class.unlock!
-      end
-    end
-  end
-
   describe '#create' do
     let(:state) { {} }
     let(:hostname) { 'example.com' }
 
     before(:each) do
       allow(Socket).to receive(:gethostname).and_return(hostname)
-    end
-
-    it 'locks the class-level Mutex' do
-      expect(described_class).to receive(:lock!)
-      driver.create(state)
     end
 
     it 'adds the system hostname to the state' do
@@ -125,11 +57,6 @@ describe Kitchen::Driver::Localhost do
       expect(d).to receive(:rm_rf).with(provisioner_path)
       expect(d).to receive(:rm_rf).with(verifier_path)
       d.destroy(state)
-    end
-
-    it 'unlocks the class-level Mutex' do
-      expect(described_class).to receive(:unlock!)
-      driver.destroy(state)
     end
   end
 end

--- a/spec/kitchen/instance_patch_spec.rb
+++ b/spec/kitchen/instance_patch_spec.rb
@@ -21,6 +21,38 @@ describe Kitchen::Instance do
     )
   end
 
+  describe '.lock' do
+    it 'returns a Mutex' do
+      expect(described_class.lock).to be_an_instance_of(Mutex)
+    end
+  end
+
+  describe '#test' do
+    context 'a non-Localhost driver' do
+      let(:driver) { Kitchen::Driver::Dummy.new }
+
+      it 'does nothing with the class Mutex' do
+        i = instance
+        expect(described_class).not_to receive(:lock)
+        expect(i).to receive(:old_test).with(:passing)
+        i.test
+      end
+    end
+
+    context 'the Localhost driver' do
+      let(:driver) { Kitchen::Driver::Localhost.new }
+      let(:lock) { double }
+
+      it 'locks the class Mutex' do
+        i = instance
+        expect(described_class).to receive(:lock).and_return(lock)
+        expect(lock).to receive(:synchronize).and_yield
+        expect(i).to receive(:old_test).with(:passing)
+        i.test
+      end
+    end
+  end
+
   describe '#setup_transport' do
     context 'a non-Localhost driver' do
       let(:driver) { Kitchen::Driver::Dummy.new }


### PR DESCRIPTION
Windows failures in concurrent mode because a destroy action tries to delete the tempfile another action is still using.
