### PR TITLE
Speed up/robustify the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,12 @@
-language: ruby
-
-cache:
-  - bundler
-  - directories:
-    - /tmp/verifier/gems
-sudo: true
+language: objective-c
 
 branches:
   only:
     - master
 
 install:
-  - bundle update
+  - curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- -P chefdk
+  - chef exec bundle install
 
 script:
-  - bundle exec rake && bundle exec kitchen test -c 2
-
-rvm:
-- ruby-head
-- 2.0.0
-- 1.9.3
+  - chef exec bundle exec kitchen test -c 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 
 install:
   - curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- -P chefdk
-  - chef exec bundle install
+  - chef exec bundle update
 
 script:
   - chef exec bundle exec kitchen test -c 2

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 [![Gem Version](https://img.shields.io/gem/v/kitchen-localhost.svg)][gem]
-[![Linux Build Status](https://img.shields.io/travis/RoboticCheese/kitchen-localhost.svg)][travis]
+[![Linux Build Status](https://img.shields.io/circleci/project/RoboticCheese/kitchen-localhost.svg)][circle]
 [![Windows Build Status](https://img.shields.io/appveyor/ci/RoboticCheese/kitchen-localhost.svg)][appveyor]
-[![OS X Build Status](https://img.shields.io/circleci/project/RoboticCheese/kitchen-localhost.svg)][circle]
+[![OS X Build Status](https://img.shields.io/travis/RoboticCheese/kitchen-localhost.svg)][travis]
 [![Code Climate](https://img.shields.io/codeclimate/github/RoboticCheese/kitchen-localhost.svg)][codeclimate]
 [![Coverage Status](https://img.shields.io/coveralls/RoboticCheese/kitchen-localhost.svg)][coveralls]
 [![Dependency Status](https://img.shields.io/gemnasium/RoboticCheese/kitchen-localhost.svg)][gemnasium]
 
 [gem]: https://rubygems.org/gems/kitchen-localhost
-[travis]: https://travis-ci.org/RoboticCheese/kitchen-localhost
-[appveyor]: https://ci.appveyor.com/project/RoboticCheese/kitchen-localhost
 [circle]: https://circleci.com/gh/RoboticCheese/kitchen-localhost
+[appveyor]: https://ci.appveyor.com/project/RoboticCheese/kitchen-localhost
+[travis]: https://travis-ci.org/RoboticCheese/kitchen-localhost
 [codeclimate]: https://codeclimate.com/github/RoboticCheese/kitchen-localhost
 [coveralls]: https://coveralls.io/r/RoboticCheese/kitchen-localhost
 [gemnasium]: https://gemnasium.com/RoboticCheese/kitchen-localhost

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Gem Version](https://img.shields.io/gem/v/kitchen-localhost.svg)][gem]
-[![Build Status](https://img.shields.io/travis/RoboticCheese/kitchen-localhost.svg)][travis]
+[![Linux Build Status](https://img.shields.io/travis/RoboticCheese/kitchen-localhost.svg)][travis]
 [![Windows Build Status](https://img.shields.io/appveyor/ci/RoboticCheese/kitchen-localhost.svg)][appveyor]
+[![OS X Build Status](https://img.shields.io/circleci/project/RoboticCheese/kitchen-localhost.svg)][circle]
 [![Code Climate](https://img.shields.io/codeclimate/github/RoboticCheese/kitchen-localhost.svg)][codeclimate]
 [![Coverage Status](https://img.shields.io/coveralls/RoboticCheese/kitchen-localhost.svg)][coveralls]
 [![Dependency Status](https://img.shields.io/gemnasium/RoboticCheese/kitchen-localhost.svg)][gemnasium]
@@ -8,6 +9,7 @@
 [gem]: https://rubygems.org/gems/kitchen-localhost
 [travis]: https://travis-ci.org/RoboticCheese/kitchen-localhost
 [appveyor]: https://ci.appveyor.com/project/RoboticCheese/kitchen-localhost
+[circle]: https://circleci.com/gh/RoboticCheese/kitchen-localhost
 [codeclimate]: https://codeclimate.com/github/RoboticCheese/kitchen-localhost
 [coveralls]: https://coveralls.io/r/RoboticCheese/kitchen-localhost
 [gemnasium]: https://gemnasium.com/RoboticCheese/kitchen-localhost

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,29 +2,15 @@ branches:
   only:
     - master
 
-environment:
-  matrix:
-    # TODO: Test Kitchen won't work on Ruby 2.2 for Windows until net-ssh
-    # 2.10.x is released and Test Kitchen's version constraints is bumped to
-    # fix the references to the no-longer-existing 'dl/import'.
-    # - ruby_version: 22
-    - ruby_version: 200
-    - ruby_version: 193
-
 cache:
-  - C:\Ruby%ruby_version%\bin
-  - C:\Ruby%ruby_version%\lib\ruby\gems
   - '%TEMP%\verifier\gems'
 
 install:
-  # Install chef-client as the quickest way to get a working tar for Gecode
-  - cinst chef-client
-  - SET PATH=C:\opscode\chef\bin;%PATH%
-  - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
+  - cinst chefdk
+  - SET PATH=C:\opscode\chefdk\bin;%PATH%
 
 build_script:
-  - bundle update
+  - chef exec bundle install
 
 test_script:
-  - bundle exec rake
-  - bundle exec kitchen test -c 2
+  - chef exec bundle exec kitchen test -c 2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ install:
   - SET PATH=C:\opscode\chefdk\bin;%PATH%
 
 build_script:
-  - chef exec bundle install
+  - chef exec bundle update
 
 test_script:
   - chef exec bundle exec kitchen test -c 2

--- a/circle.yml
+++ b/circle.yml
@@ -7,12 +7,9 @@ dependencies:
     - rvm install 2.0.0-p645
     - rvm install 1.9.3-p545
   override:
-    #- rvm-exec 2.1.6 bundle install
-    #- rvm-exec 2.0.0-p645 bundle install
-    #- rvm-exec 1.9.3-p545 bundle install
-    - rvm-exec 2.1.6 gem install test-kitchen rspec rubocop
-    - rvm-exec 2.0.0-p645 gem install test-kitchen rspec rubocop
-    - rvm-exec 1.9.3-p545 gem install test-kitchen rspec rubocop
+    - rvm-exec 2.1.6 bundle install
+    - rvm-exec 2.0.0-p645 bundle install
+    - rvm-exec 1.9.3-p545 bundle install
   cache_directories:
     - /home/ubuntu/.rvm/gems
 
@@ -21,4 +18,4 @@ test:
     - rvm-exec 2.1.6 bundle exec rake
     - rvm-exec 2.0.0-p645 bundle exec rake
     - rvm-exec 1.9.3-p545 bundle exec rake
-    - bundle exec kitchen verify
+    - bundle exec kitchen test -c 2

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,24 @@
 machine:
   ruby:
-    version:
-      - 2.1.0
-      - 2.0.0-p645
-      - 1.9.3-p551
+
+dependencies:
+  pre:
+    - rvm install 2.1.6
+    - rvm install 2.0.0-p645
+    - rvm install 1.9.3-p545
+  override:
+    #- rvm-exec 2.1.6 bundle install
+    #- rvm-exec 2.0.0-p645 bundle install
+    #- rvm-exec 1.9.3-p545 bundle install
+    - rvm-exec 2.1.6 gem install test-kitchen rspec rubocop
+    - rvm-exec 2.0.0-p645 gem install test-kitchen rspec rubocop
+    - rvm-exec 1.9.3-p545 gem install test-kitchen rspec rubocop
+  cache_directories:
+    - /home/ubuntu/.rvm/gems
+
 test:
-  post:
-    - chef exec bundle exec kitchen verify
+  override:
+    - rvm-exec 2.1.6 bundle exec rake
+    - rvm-exec 2.0.0-p645 bundle exec rake
+    - rvm-exec 1.9.3-p545 bundle exec rake
+    - bundle exec kitchen verify

--- a/circle.yml
+++ b/circle.yml
@@ -7,9 +7,9 @@ dependencies:
     - rvm install 2.0.0-p645
     - rvm install 1.9.3-p545
   override:
-    - rvm-exec 2.1.6 bundle install
-    - rvm-exec 2.0.0-p645 bundle install
-    - rvm-exec 1.9.3-p545 bundle install
+    - rvm-exec 2.1.6 bundle update
+    - rvm-exec 2.0.0-p645 bundle update
+    - rvm-exec 1.9.3-p545 bundle update
   cache_directories:
     - /home/ubuntu/.rvm/gems
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,13 @@
 machine:
   ruby:
+    version: 2.1.6
 
 dependencies:
   pre:
-    - rvm install 2.1.6
     - rvm install 2.0.0-p645
     - rvm install 1.9.3-p545
   override:
-    - rvm-exec 2.1.6 bundle update
+    - bundle update
     - rvm-exec 2.0.0-p645 bundle update
     - rvm-exec 1.9.3-p545 bundle update
   cache_directories:
@@ -15,7 +15,7 @@ dependencies:
 
 test:
   override:
-    - rvm-exec 2.1.6 bundle exec rake
+    - bundle exec rake
     - rvm-exec 2.0.0-p645 bundle exec rake
     - rvm-exec 1.9.3-p545 bundle exec rake
     - bundle exec kitchen test -c 2

--- a/circle.yml
+++ b/circle.yml
@@ -1,11 +1,9 @@
 machine:
-  xcode:
-
-dependencies:
-  override:
-    - curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- -P chefdk
-    - chef exec bundle install
-
+  ruby:
+    version:
+      - 2.1.0
+      - 2.0.0-p645
+      - 1.9.3-p551
 test:
-  override:
+  post:
     - chef exec bundle exec kitchen verify

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,11 @@
+machine:
+  xcode:
+
+dependencies:
+  override:
+    - curl -L https://www.chef.io/chef/install.sh | sudo bash -s -- -P chefdk
+    - chef exec bundle install
+
+test:
+  override:
+    - chef exec bundle exec kitchen verify


### PR DESCRIPTION
A build should consist of four main parts:

**_Unit and lint tests**_
- `bundle exec rake`
- Must run against a matrix of Ruby versions (not ChefDK)

**_Real-world tests on Linux**_
- TravisCI or CircleCI (the only two I know that support building Docker containers)
- Can use ChefDK for gem install speed
- Can skip unit/lint and the build matrix
- But can share a build environment with the unit/lint tests

**_Real-world Kitchen tests on OS X**_
- TravisCI (CircleCI if/when OS X builds graduate from beta or get enabled on my account)
- Can use ChefDK for gem install speed
- Can skip unit/lint and the build matrix

**_Real-world Kitchen tests on Windows**_
- AppVeyor
- Can use ChefDK for gem install speed
- Can skip unit/lint and the build matrix
